### PR TITLE
Fix version conflicts caused by PR#56

### DIFF
--- a/Hexio.EFCore.Postgres/Hexio.EFCore.Postgres.csproj
+++ b/Hexio.EFCore.Postgres/Hexio.EFCore.Postgres.csproj
@@ -6,12 +6,12 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.6" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Npgsql.EntityFrameworkCore.PostgreSQL from 5.0.1 to 5.0.6. [(PR#56)](https://github.com/HexioDK/EFCore.Postgres/pull/56).
Hope this fix can help you.

Best regards,
sucrose